### PR TITLE
Fix the issue that written EEPROM UNIQUE ID is erased by FW flash etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ ParentFolder<br>
 -p \<port number>: COM port number to Arduino ISP<br>
 -b : set fuse bit<br>
 -u <max 6byte, hex>: write 6byte unique id to EEPROM<br>
--f \<sketch name>: flash sketch w/ arduino bootloader<br>
+-f \<sketch name>: flash firmware w/ arduino bootloader<br>
+-r : Force recompile (also require -f option)<br>
 
 - For example, move flasher folder using "cd" and then...
 


### PR DESCRIPTION
1. Fix the issue that written EEPROM UNIQUE ID is erased by FW flash
2. Set the path for avrdude and arduino-builder
3. Skip compilation if firmware has already been generated and create an option to enable force compile
